### PR TITLE
Add a description to NVDA+X command

### DIFF
--- a/addon/globalPlugins/captionImage.py
+++ b/addon/globalPlugins/captionImage.py
@@ -23,11 +23,18 @@ from comtypes.client import CreateObject as COMCreate
 from comtypes.gen.ISimpleDOM import ISimpleDOMDocument
 import controlTypes
 import subprocess
+import addonHandler
+
+ADDON_SUMMARY = addonHandler.getCodeAddon().manifest["summary"]
 
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
-	@script(gesture="kb:NVDA+x")
+	@script(
+		# Translators: message presented in input help mode, when user presses the shortcut keys for this addon.
+		description=_('Describe an image with {name}').format(name=ADDON_SUMMARY),
+		gesture="kb:NVDA+x",
+	)
 	def script_captionPhotograph(self, gesture):
 		wx.InitAllImageHandlers()
 		filename = self.get_selected_file()


### PR DESCRIPTION
Hello

### Issue
1. There is no description of the NVDA+X while in input help (NVDA+1)
2. The shortcut NVDA+X does not appear in input gesture dialog; thus it cannot be modified or removed if needed (e.g. if it conflicts with another add-on)

### Solution
Added a description to the script.

Note: The command appears in the Misc category of the input gesture dialog. This does not seem a problem to me since this add-on has only one command. But in case you prefer this add-on to have its onw command category in the input gesture dialog, I may add it.

